### PR TITLE
Remove CoffeeScript artifacts from codebase

### DIFF
--- a/modules/scripts/directives/action-overflow.js
+++ b/modules/scripts/directives/action-overflow.js
@@ -1,4 +1,8 @@
-angular.module('bp').directive('bpActionOverflow', function($window, bpConfig, BpTap) {
+angular.module('bp').directive('bpActionOverflow', function(
+  $window,
+  bpConfig,
+  BpTap) {
+
   return {
     restrict: 'E',
     transclude: true,
@@ -14,7 +18,6 @@ angular.module('bp').directive('bpActionOverflow', function($window, bpConfig, B
     },
     compile: function(elem, attrs, transcludeFn) {
       return function(scope, element, attrs) {
-        var open
         if (bpConfig.platform === 'ios') {
           element.attr('aria-hidden', 'true')
         } else {
@@ -22,21 +25,25 @@ angular.module('bp').directive('bpActionOverflow', function($window, bpConfig, B
             role: 'button',
             'aria-has-popup': 'true'
           })
+
           new BpTap(scope, element, attrs)
-          open = false
+          var open = false
+
           transcludeFn(scope, function(clone) {
-            var $$window, $actions, $menu
-            $actions = clone.filter('bp-action')
+            var $actions = clone.filter('bp-action')
             $actions.each(function() {
-              var $action
-              $action = angular.element(this)
-              $action.attr('role', 'menu-item').addClass('bp-button')
+              var $action = angular.element(this)
+              $action
+                .attr('role', 'menu-item')
+                .addClass('bp-button')
             })
-            $menu = angular.element('<bp-action-overflow-menu>').attr({
-              role: 'menu',
-              'aria-hidden': 'true'
-            }).append($actions)
-            $$window = angular.element($window)
+            var $menu = angular.element('<bp-action-overflow-menu>')
+              .attr({
+                role: 'menu',
+                'aria-hidden': 'true'
+              }).append($actions)
+
+            var $$window = angular.element($window)
             element.append($menu)
             element.on('tap', function() {
               if (open) {

--- a/modules/scripts/directives/detail-disclosure.js
+++ b/modules/scripts/directives/detail-disclosure.js
@@ -1,4 +1,7 @@
-angular.module('bp').directive('bpDetailDisclosure', function(bpConfig, $rootScope) {
+angular.module('bp').directive('bpDetailDisclosure', function(
+  bpConfig,
+  $rootScope) {
+
   return {
     restrict: 'E',
     link: function(scope, element) {

--- a/modules/scripts/directives/iscroll.js
+++ b/modules/scripts/directives/iscroll.js
@@ -24,10 +24,12 @@ angular.module('bp').directive('bpIscroll', function(bpConfig, $timeout) {
         scrollbars: true
       }, bpConfig.iscroll)
       $timeout(function() {
-        var isc, iscs, selector
-        isc = new IScroll(element.get(0), options)
-        if ((attrs.bpIscrollSticky != null) && bpConfig.platform !== 'android') {
-          selector = attrs.bpIscrollSticky || 'bp-table-header'
+        var iscs
+        var isc = new IScroll(element.get(0), options)
+        if ((attrs.bpIscrollSticky != null) &&
+          bpConfig.platform !== 'android') {
+
+          var selector = attrs.bpIscrollSticky || 'bp-table-header'
           iscs = new IScrollSticky(isc, selector)
         }
         scope.setIScroll(isc, iscs)

--- a/modules/scripts/directives/scroll.js
+++ b/modules/scripts/directives/scroll.js
@@ -1,6 +1,6 @@
 angular.module('bp').directive('bpScroll', function() {
   return function(scope, element) {
-    element.bind('touchstart', function() {})
+    element.bind('touchstart', angular.noop)
     scope.$on('$destroy', function() {
       element.unbind('touchstart')
     })

--- a/modules/scripts/directives/search.js
+++ b/modules/scripts/directives/search.js
@@ -1,38 +1,65 @@
-angular.module('bp').directive('bpSearch', function($compile, $timeout, $window, BpTap, bpConfig) {
+angular.module('bp').directive('bpSearch', function(
+  $compile,
+  $timeout,
+  $window,
+  BpTap,
+  bpConfig) {
+
   return {
     restrict: 'E',
     link: function(scope, element) {
-      var $bgLeft, $bgRight, $cancel, $placeholder, $search, $tapLayer, cancelWidth, childScope, ios
-      ios = bpConfig.platform === 'ios'
-      childScope = scope.$new(true)
+      var ios = bpConfig.platform === 'ios'
+      var childScope = scope.$new(true)
+
+      var $bgLeft, $bgRight, $cancel
       if (ios) {
         $bgLeft = angular.element('<bp-search-bg-left>')
         $bgRight = angular.element('<bp-search-bg-right>')
-        $cancel = $compile('<bp-action class="bp-button">Cancel</bp-action>')(childScope)
+        $cancel = $compile(angular.element('<bp-action>')
+          .addClass('bp-button')
+          .text('Cancel'))(childScope)
       }
-      $placeholder = $compile('<bp-search-placeholder> <bp-action class="bp-icon bp-icon-search"></bp-action> <span>{{ placeholder }}</span> </bp-search-placeholder>')(childScope)
-      $tapLayer = angular.element('<bp-search-tap>')
-      $search = element.find('input').attr({
+
+      var $placeholder = $compile(angular.element('<bp-search-placeholder>')
+        .append(
+          angular.element('<bp-action>')
+            .addClass('bp-icon bp-icon-search')
+        )
+        .append(
+          angular.element('<span>')
+            .attr('ng-bind', 'placeholder')
+        )
+      )(childScope)
+
+      var $tapLayer = angular.element('<bp-search-tap>')
+      var $search = element.find('input').attr({
         required: 'required',
         type: 'search'
       })
+
       childScope.placeholder = $search.attr('placeholder')
       if (childScope.placeholder == null) {
         childScope.placeholder = 'Search'
       }
+
       if (ios) {
         new BpTap(childScope, $cancel, {})
       }
       new BpTap(childScope, $tapLayer, {})
-      element.attr('role', 'search').prepend($bgLeft, $bgRight).append($placeholder, $cancel, $tapLayer)
+
+      element
+        .attr('role', 'search')
+        .prepend($bgLeft, $bgRight)
+        .append($placeholder, $cancel, $tapLayer)
+
       if (ios) {
-        cancelWidth = null
+        var cancelWidth
         $timeout(function() {
-          var iconWidth, inputWidth, width
-          width = element.outerWidth()
+          var width = element.outerWidth()
           cancelWidth = $cancel.outerWidth()
-          iconWidth = $placeholder.find('.bp-icon').outerWidth()
-          inputWidth = width - cancelWidth - 6
+          var inputWidth = width - cancelWidth - 6
+          var iconWidth = $placeholder.find('.bp-icon').outerWidth()
+
           $bgLeft.css('width', inputWidth)
           $bgRight.css('width', cancelWidth)
           $search.css({
@@ -40,11 +67,12 @@ angular.module('bp').directive('bpSearch', function($compile, $timeout, $window,
             'padding-left': 1.5 * iconWidth
           })
         }, 50)
+
         childScope.onResize = function() {
-          var inputWidth
-          inputWidth = element.outerWidth() - cancelWidth
+          var inputWidth = element.outerWidth() - cancelWidth
           $bgLeft.css('width', inputWidth)
         }
+
         childScope.onCancel = function() {
           element.removeClass('focus')
           $search.val('').trigger('input').trigger('blur', {
@@ -52,6 +80,7 @@ angular.module('bp').directive('bpSearch', function($compile, $timeout, $window,
           })
         }
       }
+
       childScope.onBlur = function(e, extra) {
         if (extra == null) {
           extra = {}
@@ -62,23 +91,30 @@ angular.module('bp').directive('bpSearch', function($compile, $timeout, $window,
           $cancel.trigger('tap')
         }
       }
+
       childScope.onFocus = function() {
         $search.focus()
         $timeout(function() {
           element.addClass('focus')
         }, 0)
       }
+
       childScope.stopPropagation = function(e) {
         e.stopPropagation()
         e.stopImmediatePropagation()
       }
+
       if (ios) {
-        angular.element($window).bind('resize orientationchange', childScope.onResize)
+        angular.element($window)
+          .bind('resize orientationchange', childScope.onResize)
         $cancel.bind('tap', childScope.onCancel)
       }
+
       $search.bind('blur', childScope.onBlur)
-      $tapLayer.bind('tap', childScope.onFocus)
-      $tapLayer.bind('click touchstart touchmove touchend', childScope.stopPropagation)
+      $tapLayer
+        .bind('tap', childScope.onFocus)
+        .bind('click touchstart touchmove touchend', childScope.stopPropagation)
+
       scope.$on('$destroy', function() {
         childScope.$destroy()
         if (ios) {

--- a/modules/scripts/directives/tabbar.js
+++ b/modules/scripts/directives/tabbar.js
@@ -18,33 +18,44 @@ angular.module('bp').directive('bpTab', function($state, $compile, $timeout) {
       bpTabTitle: '@'
     },
     link: function(scope, element, attrs) {
-      var $icon, $title, state
       element.attr({
         role: 'tab'
       })
-      state = $state.get(scope.bpSref)
-      if (attrs.bpTabTitle == null) {
-        if (state.data && state.data.title) {
+      var state = $state.get(scope.bpSref)
+      if (angular.isUndefined(attrs.bpTabTitle)) {
+        if (angular.isObject(state.data) && state.data.title) {
           attrs.bpTabTitle = state.data.title
         } else if (state.name) {
-          attrs.bpTabTitle = state.name.charAt(0).toUpperCase() + state.name.slice(1)
+          attrs.bpTabTitle = state.name.charAt(0).toUpperCase() +
+            state.name.slice(1)
         }
       }
-      $icon = $compile('<span class="bp-icon {{bpTabIcon}}"></span>')(scope)
-      $title = $compile('<span>{{ bpTabTitle }}</span>')(scope)
+      var $icon = $compile(angular.element('<span>')
+        .addClass('bp-icon {{bpTabIcon}}'))(scope)
+
+      var $title = $compile(angular.element('<span>')
+        .attr('ng-bind', 'bpTabTitle'))(scope)
+
       element.append($icon, $title)
+
       scope.$on('$stateChangeSuccess', function() {
         if ($state.includes(scope.bpSref)) {
-          element.addClass('bp-tab-active').attr('aria-selected', 'true')
+          element
+            .addClass('bp-tab-active')
+            .attr('aria-selected', 'true')
         } else {
-          element.removeClass('bp-tab-active').attr('aria-selected', 'false')
+          element
+            .removeClass('bp-tab-active')
+            .attr('aria-selected', 'false')
         }
       })
+
       element.bind('touchstart', function() {
         $timeout(function() {
           element.trigger('touchend')
         }, 500)
       })
+
       scope.$on('$destroy', function() {
         element.unbind('touchstart')
       })

--- a/modules/scripts/directives/toolbar.js
+++ b/modules/scripts/directives/toolbar.js
@@ -14,9 +14,12 @@ angular.module('bp').directive('bpToolbar', function(bpConfig) {
             var $actions
             $actions = clone.filter('bp-action')
             $actions.each(function() {
-              var $action
-              $action = angular.element(this)
-              $action.attr('aria-label', $action.text()).text('').removeClass('bp-button').addClass('bp-icon')
+              var $action = angular.element(this)
+              $action
+                .attr('aria-label', $action.text())
+                .text('')
+                .removeClass('bp-button')
+                .addClass('bp-icon')
             })
             element.append($actions)
           })

--- a/modules/scripts/services/config.js
+++ b/modules/scripts/services/config.js
@@ -1,6 +1,5 @@
 angular.module('bp').provider('bpConfig', (function() {
-  var config
-  config = {
+  var config = {
     platform: 'ios'
   }
 

--- a/modules/scripts/services/config.js
+++ b/modules/scripts/services/config.js
@@ -1,25 +1,21 @@
 angular.module('bp').provider('bpConfig', (function() {
-  var BpConfig
-  return BpConfig = (function() {
-    var config
+  var config
+  config = {
+    platform: 'ios'
+  }
 
-    config = {
-      platform: 'ios'
-    }
+  function BpConfig() {
+    config.setConfig = this.setConfig
+  }
 
-    function BpConfig() {
-      config.setConfig = this.setConfig
-    }
+  BpConfig.prototype.$get = function() {
+    return config
+  }
 
-    BpConfig.prototype.$get = function() {
-      return config
-    }
+  BpConfig.prototype.setConfig = function(inConfig) {
+    config = angular.extend(config, inConfig)
+  }
 
-    BpConfig.prototype.setConfig = function(inConfig) {
-      config = angular.extend(config, inConfig)
-    }
+  return BpConfig
 
-    return BpConfig
-
-  })()
 })())

--- a/modules/scripts/services/tap.js
+++ b/modules/scripts/services/tap.js
@@ -1,5 +1,3 @@
-// var __bind = function(fn, me) { return function() { return fn.apply(me, arguments)  }  }
-
 angular.module('bp').factory('BpTap', function(bpConfig) {
   function BpTap(scope, element, attrs, customOptions) {
     this.element      = element
@@ -38,7 +36,10 @@ angular.module('bp').factory('BpTap', function(bpConfig) {
     this.touch.ongoing  = true
     $t                  = angular.element(e.target)
 
-    if ((($t.attr('bp-tap') != null) || ($t.attr('bp-sref') != null)) && this.element.get(0) !== e.target) {
+    if ((($t.attr('bp-tap') != null) ||
+      ($t.attr('bp-sref') != null)) &&
+      this.element.get(0) !== e.target) {
+
       this.touch.nestedTap = true
     } else {
       this.element.addClass(this.options.activeClass)
@@ -50,7 +51,10 @@ angular.module('bp').factory('BpTap', function(bpConfig) {
     x = this._getCoordinate(e, true)
     y = this._getCoordinate(e, false)
 
-    if ((this.options.boundMargin != null) && (Math.abs(this.touch.y - y) < this.options.boundMargin && Math.abs(this.touch.x - x) < this.options.boundMargin)) {
+    if ((this.options.boundMargin != null) &&
+      (Math.abs(this.touch.y - y) < this.options.boundMargin &&
+        Math.abs(this.touch.x - x) < this.options.boundMargin)) {
+
       if (!this.touch.nestedTap) {
         this.element.addClass(this.options.activeClass)
       }
@@ -75,8 +79,6 @@ angular.module('bp').factory('BpTap', function(bpConfig) {
   }
 
   BpTap.prototype._setOptions = function(attrs, customOptions) {
-    var attr, key, options
-
     if (attrs == null) {
       attrs = {}
     }
@@ -84,15 +86,17 @@ angular.module('bp').factory('BpTap', function(bpConfig) {
       customOptions = {}
     }
 
-    options = {
+    var options = angular.extend({
       activeClass: 'bp-active',
       allowClick: false,
       boundMargin: 50,
       noScroll: false
-    }
-    options = angular.extend(options, bpConfig.tap || {})
+    }, bpConfig.tap || {})
 
-    if ((this.element.is('bp-action') && this.element.parent('bp-navbar')) || this.element.is('bp-detail-disclosure')) {
+    if ((this.element.is('bp-action') &&
+      this.element.parent('bp-navbar')) ||
+      this.element.is('bp-detail-disclosure')) {
+
       this.element.attr('bp-no-scroll', '')
       options.noScroll = true
     }
@@ -104,8 +108,8 @@ angular.module('bp').factory('BpTap', function(bpConfig) {
 
     angular.extend(options, customOptions)
 
-    for (key in options) {
-      attr = attrs['bp' + (key.charAt(0).toUpperCase()) + (key.slice(1))]
+    for (var key in options) {
+      var attr = attrs['bp' + (key.charAt(0).toUpperCase()) + (key.slice(1))]
       if (attr != null) {
         options[key] = attr === '' ? true : attr
       }
@@ -124,7 +128,9 @@ angular.module('bp').factory('BpTap', function(bpConfig) {
 
     if (e[axis] != null) {
       return e[axis]
-    } else if (angular.isObject(e.changedTouches) && angular.isObject(e.changedTouches[0])) {
+    } else if (angular.isObject(e.changedTouches) &&
+      angular.isObject(e.changedTouches[0])) {
+
       return e.changedTouches[0][axis]
     } else {
       return 0

--- a/modules/scripts/services/tap.js
+++ b/modules/scripts/services/tap.js
@@ -1,124 +1,120 @@
 var __bind = function(fn, me) { return function() { return fn.apply(me, arguments)  }  }
 
 angular.module('bp').factory('BpTap', function(bpConfig) {
-  var BpTap
-  return BpTap = (function() {
-    function BpTap(scope, element, attrs, customOptions) {
-      this.element = element
-      this.onTouchend = __bind(this.onTouchend, this)
-      this.onTouchmove = __bind(this.onTouchmove, this)
-      this.onTouchstart = __bind(this.onTouchstart, this)
-      this.touch = {}
-      this._setOptions(attrs, customOptions)
-      if ((!this.options.allowClick) && 'ontouchstart' in window) {
-        this.element.bind('click', this.onClick)
-      }
-      this.element.bind('touchstart', this.onTouchstart)
-      this.element.bind('touchmove', this.onTouchmove)
-      this.element.bind('touchend touchcancel', this.onTouchend)
-      scope.$on('$destroy', (function(_this) {
-        return function() {
-          _this.element.unbind('touchstart touchmove touchend touchcancel click')
-        }
-      })(this))
+  function BpTap(scope, element, attrs, customOptions) {
+    this.element = element
+    this.onTouchend = __bind(this.onTouchend, this)
+    this.onTouchmove = __bind(this.onTouchmove, this)
+    this.onTouchstart = __bind(this.onTouchstart, this)
+    this.touch = {}
+    this._setOptions(attrs, customOptions)
+    if ((!this.options.allowClick) && 'ontouchstart' in window) {
+      this.element.bind('click', this.onClick)
     }
-
-    BpTap.prototype.onClick = function(e) {
-      e.preventDefault()
-      e.stopPropagation()
-      if (angular.isFunction(e.stopImmediatePropagation)) {
-        e.stopImmediatePropagation()
+    this.element.bind('touchstart', this.onTouchstart)
+    this.element.bind('touchmove', this.onTouchmove)
+    this.element.bind('touchend touchcancel', this.onTouchend)
+    scope.$on('$destroy', (function(_this) {
+      return function() {
+        _this.element.unbind('touchstart touchmove touchend touchcancel click')
       }
-    }
+    })(this))
+  }
 
-    BpTap.prototype.onTouchstart = function(e) {
-      var $t
-      this.touch.x = this._getCoordinate(e, true)
-      this.touch.y = this._getCoordinate(e, false)
-      this.touch.ongoing = true
-      $t = angular.element(e.target)
-      if ((($t.attr('bp-tap') != null) || ($t.attr('bp-sref') != null)) && this.element.get(0) !== e.target) {
-        this.touch.nestedTap = true
-      } else {
+  BpTap.prototype.onClick = function(e) {
+    e.preventDefault()
+    e.stopPropagation()
+    if (angular.isFunction(e.stopImmediatePropagation)) {
+      e.stopImmediatePropagation()
+    }
+  }
+
+  BpTap.prototype.onTouchstart = function(e) {
+    var $t
+    this.touch.x = this._getCoordinate(e, true)
+    this.touch.y = this._getCoordinate(e, false)
+    this.touch.ongoing = true
+    $t = angular.element(e.target)
+    if ((($t.attr('bp-tap') != null) || ($t.attr('bp-sref') != null)) && this.element.get(0) !== e.target) {
+      this.touch.nestedTap = true
+    } else {
+      this.element.addClass(this.options.activeClass)
+    }
+  }
+
+  BpTap.prototype.onTouchmove = function(e) {
+    var x, y
+    x = this._getCoordinate(e, true)
+    y = this._getCoordinate(e, false)
+    if ((this.options.boundMargin != null) && (Math.abs(this.touch.y - y) < this.options.boundMargin && Math.abs(this.touch.x - x) < this.options.boundMargin)) {
+      if (!this.touch.nestedTap) {
         this.element.addClass(this.options.activeClass)
       }
-    }
-
-    BpTap.prototype.onTouchmove = function(e) {
-      var x, y
-      x = this._getCoordinate(e, true)
-      y = this._getCoordinate(e, false)
-      if ((this.options.boundMargin != null) && (Math.abs(this.touch.y - y) < this.options.boundMargin && Math.abs(this.touch.x - x) < this.options.boundMargin)) {
-        if (!this.touch.nestedTap) {
-          this.element.addClass(this.options.activeClass)
-        }
-        this.touch.ongoing = true
-        if (this.options.noScroll) {
-          e.preventDefault()
-        }
-      } else {
-        this.touch.ongoing = false
-        this.element.removeClass(this.options.activeClass)
+      this.touch.ongoing = true
+      if (this.options.noScroll) {
+        e.preventDefault()
       }
-    }
-
-    BpTap.prototype.onTouchend = function(e) {
-      if (this.touch.ongoing && !this.touch.nestedTap && e.type === 'touchend') {
-        this.element.trigger('tap', this.touch)
-      }
-      this.touch = {}
+    } else {
+      this.touch.ongoing = false
       this.element.removeClass(this.options.activeClass)
     }
+  }
 
-    BpTap.prototype._setOptions = function(attrs, customOptions) {
-      var attr, key, options
-      if (attrs == null) {
-        attrs = {}
-      }
-      if (customOptions == null) {
-        customOptions = {}
-      }
-      options = {
-        activeClass: 'bp-active',
-        allowClick: false,
-        boundMargin: 50,
-        noScroll: false
-      }
-      options = angular.extend(options, bpConfig.tap || {})
-      if ((this.element.is('bp-action') && this.element.parent('bp-navbar')) || this.element.is('bp-detail-disclosure')) {
-        this.element.attr('bp-no-scroll', '')
-        options.noScroll = true
-      }
-      if (this.element.parents('[bp-iscroll]').length) {
-        this.element.attr('bp-bound-margin', '5')
-        options.boundMargin = 5
-      }
-      angular.extend(options, customOptions)
-      for (key in options) {
-        attr = attrs['bp' + (key.charAt(0).toUpperCase()) + (key.slice(1))]
-        if (attr != null) {
-          options[key] = attr === '' ? true : attr
-        }
-      }
-      this.options = options
+  BpTap.prototype.onTouchend = function(e) {
+    if (this.touch.ongoing && !this.touch.nestedTap && e.type === 'touchend') {
+      this.element.trigger('tap', this.touch)
     }
+    this.touch = {}
+    this.element.removeClass(this.options.activeClass)
+  }
 
-    BpTap.prototype._getCoordinate = function(e, isX) {
-      var axis, _ref
-      axis = isX ? 'pageX' : 'pageY'
-      if (e.originalEvent != null) {
-        e = e.originalEvent
-      }
-      if (e[axis] != null) {
-        return e[axis]
-      } else if (((_ref = e.changedTouches) != null ? _ref[0] : void 0) != null) {
-        return e.changedTouches[0][axis]
-      } else {
-        return 0
+  BpTap.prototype._setOptions = function(attrs, customOptions) {
+    var attr, key, options
+    if (attrs == null) {
+      attrs = {}
+    }
+    if (customOptions == null) {
+      customOptions = {}
+    }
+    options = {
+      activeClass: 'bp-active',
+      allowClick: false,
+      boundMargin: 50,
+      noScroll: false
+    }
+    options = angular.extend(options, bpConfig.tap || {})
+    if ((this.element.is('bp-action') && this.element.parent('bp-navbar')) || this.element.is('bp-detail-disclosure')) {
+      this.element.attr('bp-no-scroll', '')
+      options.noScroll = true
+    }
+    if (this.element.parents('[bp-iscroll]').length) {
+      this.element.attr('bp-bound-margin', '5')
+      options.boundMargin = 5
+    }
+    angular.extend(options, customOptions)
+    for (key in options) {
+      attr = attrs['bp' + (key.charAt(0).toUpperCase()) + (key.slice(1))]
+      if (attr != null) {
+        options[key] = attr === '' ? true : attr
       }
     }
+    this.options = options
+  }
 
-    return BpTap
+  BpTap.prototype._getCoordinate = function(e, isX) {
+    var axis, _ref
+    axis = isX ? 'pageX' : 'pageY'
+    if (e.originalEvent != null) {
+      e = e.originalEvent
+    }
+    if (e[axis] != null) {
+      return e[axis]
+    } else if (((_ref = e.changedTouches) != null ? _ref[0] : void 0) != null) {
+      return e.changedTouches[0][axis]
+    } else {
+      return 0
+    }
+  }
 
-  })()
+  return BpTap
 })

--- a/modules/scripts/services/tap.js
+++ b/modules/scripts/services/tap.js
@@ -1,24 +1,26 @@
-var __bind = function(fn, me) { return function() { return fn.apply(me, arguments)  }  }
+// var __bind = function(fn, me) { return function() { return fn.apply(me, arguments)  }  }
 
 angular.module('bp').factory('BpTap', function(bpConfig) {
   function BpTap(scope, element, attrs, customOptions) {
-    this.element = element
-    this.onTouchend = __bind(this.onTouchend, this)
-    this.onTouchmove = __bind(this.onTouchmove, this)
-    this.onTouchstart = __bind(this.onTouchstart, this)
-    this.touch = {}
+    this.element      = element
+    this.touch        = {}
+    this.onTouchend   = angular.bind(this, this.onTouchend)
+    this.onTouchmove  = angular.bind(this, this.onTouchmove)
+    this.onTouchstart = angular.bind(this, this.onTouchstart)
+
+    element.bind('touchstart', this.onTouchstart)
+    element.bind('touchmove', this.onTouchmove)
+    element.bind('touchend touchcancel', this.onTouchend)
+
     this._setOptions(attrs, customOptions)
+
     if ((!this.options.allowClick) && 'ontouchstart' in window) {
       this.element.bind('click', this.onClick)
     }
-    this.element.bind('touchstart', this.onTouchstart)
-    this.element.bind('touchmove', this.onTouchmove)
-    this.element.bind('touchend touchcancel', this.onTouchend)
-    scope.$on('$destroy', (function(_this) {
-      return function() {
-        _this.element.unbind('touchstart touchmove touchend touchcancel click')
-      }
-    })(this))
+
+    scope.$on('$destroy', function() {
+      element.unbind('touchstart touchmove touchend touchcancel click')
+    })
   }
 
   BpTap.prototype.onClick = function(e) {
@@ -31,10 +33,11 @@ angular.module('bp').factory('BpTap', function(bpConfig) {
 
   BpTap.prototype.onTouchstart = function(e) {
     var $t
-    this.touch.x = this._getCoordinate(e, true)
-    this.touch.y = this._getCoordinate(e, false)
-    this.touch.ongoing = true
-    $t = angular.element(e.target)
+    this.touch.x        = this._getCoordinate(e, true)
+    this.touch.y        = this._getCoordinate(e, false)
+    this.touch.ongoing  = true
+    $t                  = angular.element(e.target)
+
     if ((($t.attr('bp-tap') != null) || ($t.attr('bp-sref') != null)) && this.element.get(0) !== e.target) {
       this.touch.nestedTap = true
     } else {
@@ -46,11 +49,14 @@ angular.module('bp').factory('BpTap', function(bpConfig) {
     var x, y
     x = this._getCoordinate(e, true)
     y = this._getCoordinate(e, false)
+
     if ((this.options.boundMargin != null) && (Math.abs(this.touch.y - y) < this.options.boundMargin && Math.abs(this.touch.x - x) < this.options.boundMargin)) {
       if (!this.touch.nestedTap) {
         this.element.addClass(this.options.activeClass)
       }
+
       this.touch.ongoing = true
+
       if (this.options.noScroll) {
         e.preventDefault()
       }
@@ -70,12 +76,14 @@ angular.module('bp').factory('BpTap', function(bpConfig) {
 
   BpTap.prototype._setOptions = function(attrs, customOptions) {
     var attr, key, options
+
     if (attrs == null) {
       attrs = {}
     }
     if (customOptions == null) {
       customOptions = {}
     }
+
     options = {
       activeClass: 'bp-active',
       allowClick: false,
@@ -83,33 +91,40 @@ angular.module('bp').factory('BpTap', function(bpConfig) {
       noScroll: false
     }
     options = angular.extend(options, bpConfig.tap || {})
+
     if ((this.element.is('bp-action') && this.element.parent('bp-navbar')) || this.element.is('bp-detail-disclosure')) {
       this.element.attr('bp-no-scroll', '')
       options.noScroll = true
     }
+
     if (this.element.parents('[bp-iscroll]').length) {
       this.element.attr('bp-bound-margin', '5')
       options.boundMargin = 5
     }
+
     angular.extend(options, customOptions)
+
     for (key in options) {
       attr = attrs['bp' + (key.charAt(0).toUpperCase()) + (key.slice(1))]
       if (attr != null) {
         options[key] = attr === '' ? true : attr
       }
     }
+
     this.options = options
   }
 
   BpTap.prototype._getCoordinate = function(e, isX) {
-    var axis, _ref
+    var axis
     axis = isX ? 'pageX' : 'pageY'
+
     if (e.originalEvent != null) {
       e = e.originalEvent
     }
+
     if (e[axis] != null) {
       return e[axis]
-    } else if (((_ref = e.changedTouches) != null ? _ref[0] : void 0) != null) {
+    } else if (angular.isObject(e.changedTouches) && angular.isObject(e.changedTouches[0])) {
       return e.changedTouches[0][axis]
     } else {
       return 0

--- a/modules/scripts/services/view.js
+++ b/modules/scripts/services/view.js
@@ -1,11 +1,7 @@
-var __bind = function(fn, me) { return function() { return fn.apply(me, arguments)  }  }
-
 angular.module('bp').service('bpView', function($rootScope) {
   function BpView() {
-    this.onViewContentLoaded = __bind(this.onViewContentLoaded, this)
-    this.onStateChangeStart = __bind(this.onStateChangeStart, this)
-    this.transition = null
-    this.lastTransition = null
+    this.onViewContentLoaded  = angular.bind(this, this.onViewContentLoaded)
+    this.onStateChangeStart   = angular.bind(this, this.onStateChangeStart)
   }
 
   BpView.prototype.listen = function() {
@@ -14,15 +10,13 @@ angular.module('bp').service('bpView', function($rootScope) {
   }
 
   BpView.prototype.onStateChangeStart = function(event, toState, toParams, fromState) {
-    var direction, type
-    direction = toParams.direction || this.getDirection(fromState, toState)
-    type = toParams.transition || this.getType(fromState, toState, direction)
+    var direction = toParams.direction || this.getDirection(fromState, toState)
+    var type = toParams.transition || this.getType(fromState, toState, direction)
     this.setTransition(type, direction)
   }
 
   BpView.prototype.onViewContentLoaded = function() {
-    var $views
-    $views = angular.element('[ui-view], ui-view')
+    var $views = angular.element('[ui-view], ui-view')
     if (this.transition != null) {
       $views.removeClass(this.lastTransition).addClass(this.transition)
       this.lastTransition = this.transition
@@ -40,23 +34,22 @@ angular.module('bp').service('bpView', function($rootScope) {
   }
 
   BpView.prototype.getDirection = function(from, to) {
-    var direction, fromSegments, index, segment, toSegments, _i, _len
-    direction = 'normal'
     if (from.url === '^') {
       return null
     }
-    fromSegments = this._getURLSegments(from)
-    toSegments = this._getURLSegments(to)
+
+    var direction     = 'normal'
+    var fromSegments  = this._getURLSegments(from)
+    var toSegments    = this._getURLSegments(to)
+
     if (toSegments.length < fromSegments.length) {
       direction = 'reverse'
-      for (index = _i = 0, _len = toSegments.length; _i < _len; index = ++_i) {
-        segment = toSegments[index]
-        if (segment !== fromSegments[index]) {
+      for (var index = 0; index < toSegments.length; index++) {
+        if (toSegments[index] !== fromSegments[index]) {
           direction = 'normal'
           break
         }
       }
-      direction
     } else if (toSegments.length === fromSegments.length) {
       direction = null
     }
@@ -64,19 +57,22 @@ angular.module('bp').service('bpView', function($rootScope) {
   }
 
   BpView.prototype.getType = function(from, to, direction) {
-    var _ref, _ref1
     if (direction === 'reverse') {
-      return ((_ref = from.data) != null ? _ref.transition : void 0) || null
+      if (angular.isObject(from.data)) {
+        return from.data.transition || null
+      }
     } else {
-      return ((_ref1 = to.data) != null ? _ref1.transition : void 0) || null
+      if (angular.isObject(to.data)) {
+        return to.data.transition || null
+      }
     }
+    return null
   }
 
   BpView.prototype._getURLSegments = function(state) {
-    var url
-    url = state.url || ''
-    url = url.replace(/\/$/, '')
-    return url.split('/')
+    return (state.url || '')
+      .replace(/\/$/, '')
+      .split('/')
   }
 
   return new BpView()

--- a/modules/scripts/services/view.js
+++ b/modules/scripts/services/view.js
@@ -38,25 +38,17 @@ angular.module('bp').service('bpView', function($rootScope) {
       return null
     }
 
-    var direction     = null
-    var fromSegments  = this._getURLSegments(from)
-    var toSegments    = this._getURLSegments(to)
-    var fromLength    = fromSegments.length
-    var toLength      = toSegments.length
+    var direction = null
+    var fromSegs  = this._getURLSegments(from)
+    var toSegs    = this._getURLSegments(to)
+    var fromLen   = fromSegs.length
+    var toLen     = toSegs.length
+    var diff      = toLen - fromLen
 
-    // If new url has one segment more than the old url and all but the last
-    // (additional new) segment are the same, the direction should be 'normal'.
-    if (toLength === fromLength + 1) {
-      if (fromSegments.join('') === toSegments.slice(0,toLength - 1).join('')) {
-        direction = 'normal'
-      }
-    }
-    // If new url has one segment fewer than old url and all but the last
-    // (additional old) segment are the same, the direction should be 'reversed'.
-    if (toLength === fromLength - 1) {
-      if (toSegments.join('') === fromSegments.slice(0, fromLength - 1).join('')) {
-        direction = 'reverse'
-      }
+    if (diff > 0 && angular.equals(fromSegs, toSegs.slice(0,toLen - diff))) {
+      direction = 'normal'
+    } else if (diff < 0 && angular.equals(toSegs, fromSegs.slice(0, fromLen  + diff))) {
+      direction = 'reverse'
     }
     return direction
   }

--- a/modules/scripts/services/view.js
+++ b/modules/scripts/services/view.js
@@ -9,16 +9,27 @@ angular.module('bp').service('bpView', function($rootScope) {
     $rootScope.$on('$viewContentLoaded', this.onViewContentLoaded)
   }
 
-  BpView.prototype.onStateChangeStart = function(event, toState, toParams, fromState) {
-    var direction = toParams.direction || this.getDirection(fromState, toState)
-    var type = toParams.transition || this.getType(fromState, toState, direction)
+  BpView.prototype.onStateChangeStart = function(
+    event,
+    toState,
+    toParams,
+    fromState) {
+
+    var direction = toParams.direction ||
+      this.getDirection(fromState, toState)
+
+    var type = toParams.transition ||
+      this.getType(fromState, toState, direction)
+
     this.setTransition(type, direction)
   }
 
   BpView.prototype.onViewContentLoaded = function() {
     var $views = angular.element('[ui-view], ui-view')
     if (this.transition != null) {
-      $views.removeClass(this.lastTransition).addClass(this.transition)
+      $views
+        .removeClass(this.lastTransition)
+        .addClass(this.transition)
       this.lastTransition = this.transition
     } else {
       $views.removeClass(this.lastTransition)
@@ -54,7 +65,9 @@ angular.module('bp').service('bpView', function($rootScope) {
 
     if (diff > 0 && angular.equals(fromSegs, toSegs.slice(0,toLen - diff))) {
       return 'normal'
-    } else if (diff < 0 && angular.equals(toSegs, fromSegs.slice(0, fromLen  + diff))) {
+    } else if (diff < 0 &&
+      angular.equals(toSegs, fromSegs.slice(0, fromLen  + diff))) {
+
       return 'reverse'
     }
     return null

--- a/modules/scripts/services/view.js
+++ b/modules/scripts/services/view.js
@@ -1,88 +1,83 @@
 var __bind = function(fn, me) { return function() { return fn.apply(me, arguments)  }  }
 
 angular.module('bp').service('bpView', function($rootScope) {
-  var BpView
-  BpView = (function() {
-    function BpView() {
-      this.onViewContentLoaded = __bind(this.onViewContentLoaded, this)
-      this.onStateChangeStart = __bind(this.onStateChangeStart, this)
+  function BpView() {
+    this.onViewContentLoaded = __bind(this.onViewContentLoaded, this)
+    this.onStateChangeStart = __bind(this.onStateChangeStart, this)
+    this.transition = null
+    this.lastTransition = null
+  }
+
+  BpView.prototype.listen = function() {
+    $rootScope.$on('$stateChangeStart', this.onStateChangeStart)
+    $rootScope.$on('$viewContentLoaded', this.onViewContentLoaded)
+  }
+
+  BpView.prototype.onStateChangeStart = function(event, toState, toParams, fromState) {
+    var direction, type
+    direction = toParams.direction || this.getDirection(fromState, toState)
+    type = toParams.transition || this.getType(fromState, toState, direction)
+    this.setTransition(type, direction)
+  }
+
+  BpView.prototype.onViewContentLoaded = function() {
+    var $views
+    $views = angular.element('[ui-view], ui-view')
+    if (this.transition != null) {
+      $views.removeClass(this.lastTransition).addClass(this.transition)
+      this.lastTransition = this.transition
+    } else {
+      $views.removeClass(this.lastTransition)
+    }
+  }
+
+  BpView.prototype.setTransition = function(type, direction) {
+    if (type != null && direction != null) {
+      this.transition = type + '-' + direction
+    } else {
       this.transition = null
-      this.lastTransition = null
     }
+  }
 
-    BpView.prototype.listen = function() {
-      $rootScope.$on('$stateChangeStart', this.onStateChangeStart)
-      $rootScope.$on('$viewContentLoaded', this.onViewContentLoaded)
+  BpView.prototype.getDirection = function(from, to) {
+    var direction, fromSegments, index, segment, toSegments, _i, _len
+    direction = 'normal'
+    if (from.url === '^') {
+      return null
     }
-
-    BpView.prototype.onStateChangeStart = function(event, toState, toParams, fromState) {
-      var direction, type
-      direction = toParams.direction || this.getDirection(fromState, toState)
-      type = toParams.transition || this.getType(fromState, toState, direction)
-      this.setTransition(type, direction)
-    }
-
-    BpView.prototype.onViewContentLoaded = function() {
-      var $views
-      $views = angular.element('[ui-view], ui-view')
-      if (this.transition != null) {
-        $views.removeClass(this.lastTransition).addClass(this.transition)
-        this.lastTransition = this.transition
-      } else {
-        $views.removeClass(this.lastTransition)
-      }
-    }
-
-    BpView.prototype.setTransition = function(type, direction) {
-      if (type != null && direction != null) {
-        this.transition = type + '-' + direction
-      } else {
-        this.transition = null
-      }
-    }
-
-    BpView.prototype.getDirection = function(from, to) {
-      var direction, fromSegments, index, segment, toSegments, _i, _len
-      direction = 'normal'
-      if (from.url === '^') {
-        return null
-      }
-      fromSegments = this._getURLSegments(from)
-      toSegments = this._getURLSegments(to)
-      if (toSegments.length < fromSegments.length) {
-        direction = 'reverse'
-        for (index = _i = 0, _len = toSegments.length; _i < _len; index = ++_i) {
-          segment = toSegments[index]
-          if (segment !== fromSegments[index]) {
-            direction = 'normal'
-            break
-          }
+    fromSegments = this._getURLSegments(from)
+    toSegments = this._getURLSegments(to)
+    if (toSegments.length < fromSegments.length) {
+      direction = 'reverse'
+      for (index = _i = 0, _len = toSegments.length; _i < _len; index = ++_i) {
+        segment = toSegments[index]
+        if (segment !== fromSegments[index]) {
+          direction = 'normal'
+          break
         }
-        direction
-      } else if (toSegments.length === fromSegments.length) {
-        direction = null
       }
-      return direction
+      direction
+    } else if (toSegments.length === fromSegments.length) {
+      direction = null
     }
+    return direction
+  }
 
-    BpView.prototype.getType = function(from, to, direction) {
-      var _ref, _ref1
-      if (direction === 'reverse') {
-        return ((_ref = from.data) != null ? _ref.transition : void 0) || null
-      } else {
-        return ((_ref1 = to.data) != null ? _ref1.transition : void 0) || null
-      }
+  BpView.prototype.getType = function(from, to, direction) {
+    var _ref, _ref1
+    if (direction === 'reverse') {
+      return ((_ref = from.data) != null ? _ref.transition : void 0) || null
+    } else {
+      return ((_ref1 = to.data) != null ? _ref1.transition : void 0) || null
     }
+  }
 
-    BpView.prototype._getURLSegments = function(state) {
-      var url
-      url = state.url || ''
-      url = url.replace(/\/$/, '')
-      return url.split('/')
-    }
+  BpView.prototype._getURLSegments = function(state) {
+    var url
+    url = state.url || ''
+    url = url.replace(/\/$/, '')
+    return url.split('/')
+  }
 
-    return BpView
-
-  })()
   return new BpView()
 })

--- a/modules/scripts/services/view.js
+++ b/modules/scripts/services/view.js
@@ -38,19 +38,26 @@ angular.module('bp').service('bpView', function($rootScope) {
       return null
     }
 
-    var direction = null
-    var fromSegs  = this._getURLSegments(from)
-    var toSegs    = this._getURLSegments(to)
-    var fromLen   = fromSegs.length
-    var toLen     = toSegs.length
-    var diff      = toLen - fromLen
+    if (angular.isObject(to.data) && to.data.up === from.name) {
+      return 'normal'
+    }
+
+    if (angular.isObject(from.data) && from.data.up === to.name) {
+      return 'reverse'
+    }
+
+    var fromSegs = this._getURLSegments(from)
+    var toSegs   = this._getURLSegments(to)
+    var fromLen  = fromSegs.length
+    var toLen    = toSegs.length
+    var diff     = toLen - fromLen
 
     if (diff > 0 && angular.equals(fromSegs, toSegs.slice(0,toLen - diff))) {
-      direction = 'normal'
+      return 'normal'
     } else if (diff < 0 && angular.equals(toSegs, fromSegs.slice(0, fromLen  + diff))) {
-      direction = 'reverse'
+      return 'reverse'
     }
-    return direction
+    return null
   }
 
   BpView.prototype.getType = function(from, to, direction) {

--- a/modules/scripts/services/view.js
+++ b/modules/scripts/services/view.js
@@ -38,20 +38,25 @@ angular.module('bp').service('bpView', function($rootScope) {
       return null
     }
 
-    var direction     = 'normal'
+    var direction     = null
     var fromSegments  = this._getURLSegments(from)
     var toSegments    = this._getURLSegments(to)
+    var fromLength    = fromSegments.length
+    var toLength      = toSegments.length
 
-    if (toSegments.length < fromSegments.length) {
-      direction = 'reverse'
-      for (var index = 0; index < toSegments.length; index++) {
-        if (toSegments[index] !== fromSegments[index]) {
-          direction = 'normal'
-          break
-        }
+    // If new url has one segment more than the old url and all but the last
+    // (additional new) segment are the same, the direction should be 'normal'.
+    if (toLength === fromLength + 1) {
+      if (fromSegments.join('') === toSegments.slice(0,toLength - 1).join('')) {
+        direction = 'normal'
       }
-    } else if (toSegments.length === fromSegments.length) {
-      direction = null
+    }
+    // If new url has one segment fewer than old url and all but the last
+    // (additional old) segment are the same, the direction should be 'reversed'.
+    if (toLength === fromLength - 1) {
+      if (toSegments.join('') === fromSegments.slice(0, fromLength - 1).join('')) {
+        direction = 'reverse'
+      }
     }
     return direction
   }

--- a/test/spec/directives/search.coffee
+++ b/test/spec/directives/search.coffee
@@ -145,7 +145,7 @@ describe 'searchDirective', ->
 
       it 'should execute handlers correctly', inject ($timeout) ->
         childScope = $cancel.scope()
-
+        $timeout.flush()
         $bgLeft.css 'width', ''
         childScope.onResize()
         expect($bgLeft.attr 'style').toMatch /width/

--- a/test/spec/directives/tabbar.coffee
+++ b/test/spec/directives/tabbar.coffee
@@ -13,6 +13,8 @@ describe 'tabbarDirective', ->
         url: '/first'
       .state 'second',
         url: '/second'
+        data:
+          title: 'Custom'
     null
 
   beforeEach inject ($rootScope, $compile, $state) ->
@@ -31,6 +33,10 @@ describe 'tabbarDirective', ->
       expect(element.attr 'role' ).toBe 'tablist'
 
   describe 'tab elements', ->
+    it 'should have correct name', ->
+      expect(element.children().eq(0).text()).toBe 'First'
+      expect(element.children().eq(1).text()).toBe 'Custom'
+
     it 'should have ARIA role', ->
       element.children().each (i,element) ->
         expect($(element).attr 'role' ).toBe 'tab'

--- a/test/spec/services/view.coffee
+++ b/test/spec/services/view.coffee
@@ -25,6 +25,8 @@ describe 'viewService', ->
         url: '/home/baz/fifth'
         data:
           transition: 'slide'
+      .state 'faroff',
+        url: '/home/second/foo/bar/baz'
       .state 'alien',
         url: '/crazy/route'
     return
@@ -33,7 +35,7 @@ describe 'viewService', ->
   state = null
   scope = null
 
-  home = second = third = fourth = fifth = alien = null
+  home = second = third = fourth = fifth = alien = faroff = null
 
 
   beforeEach inject ($rootScope, bpView, $state) ->
@@ -46,6 +48,8 @@ describe 'viewService', ->
     fourth = state.get 'fourth'
     fifth = state.get 'fifth'
     alien = state.get 'alien'
+    faroff = state.get 'faroff'
+
 
   describe 'listen', ->
     it 'should listen to events', ->
@@ -108,9 +112,11 @@ describe 'viewService', ->
     it 'should detect "normal"', ->
       expect(viewService.getDirection home, second).toBe 'normal'
       expect(viewService.getDirection second, third).toBe 'normal'
+      expect(viewService.getDirection home, faroff).toBe 'normal'
 
     it 'should detect "reverse"', ->
       expect(viewService.getDirection second, home).toBe 'reverse'
+      expect(viewService.getDirection faroff, home).toBe 'reverse'
 
     it 'should detect no direction', ->
       expect(viewService.getDirection fourth, fifth).toBe null

--- a/test/spec/services/view.coffee
+++ b/test/spec/services/view.coffee
@@ -25,13 +25,15 @@ describe 'viewService', ->
         url: '/home/baz/fifth'
         data:
           transition: 'slide'
+      .state 'alien',
+        url: '/crazy/route'
     return
 
   viewService = null
   state = null
   scope = null
 
-  home = second = third = fourth = fifth = null
+  home = second = third = fourth = fifth = alien = null
 
 
   beforeEach inject ($rootScope, bpView, $state) ->
@@ -43,6 +45,7 @@ describe 'viewService', ->
     third = state.get 'third'
     fourth = state.get 'fourth'
     fifth = state.get 'fifth'
+    alien = state.get 'alien'
 
   describe 'listen', ->
     it 'should listen to events', ->
@@ -104,14 +107,19 @@ describe 'viewService', ->
   describe 'getDirection', ->
     it 'should detect "normal"', ->
       expect(viewService.getDirection home, second).toBe 'normal'
-      expect(viewService.getDirection fourth, fifth).toBe 'normal'
+      expect(viewService.getDirection second, third).toBe 'normal'
 
     it 'should detect "reverse"', ->
       expect(viewService.getDirection second, home).toBe 'reverse'
 
     it 'should detect no direction', ->
+      expect(viewService.getDirection fourth, fifth).toBe null
       expect(viewService.getDirection third, fifth).toBe null
       expect(viewService.getDirection {url: '^'}).toBe null
+      expect(viewService.getDirection alien, second).toBe null
+      expect(viewService.getDirection alien, fifth).toBe null
+      expect(viewService.getDirection third, fifth).toBe null
+      expect(viewService.getDirection home, alien).toBe null
 
   describe 'getType', ->
     it 'should detect "normal" type', ->

--- a/test/spec/services/view.coffee
+++ b/test/spec/services/view.coffee
@@ -44,11 +44,6 @@ describe 'viewService', ->
     fourth = state.get 'fourth'
     fifth = state.get 'fifth'
 
-  describe 'construction', ->
-    it 'should be initted', ->
-      expect(viewService.transition).toBe null
-      expect(viewService.lastTransition).toBe null
-
   describe 'listen', ->
     it 'should listen to events', ->
       spyOn viewService, 'onStateChangeStart'

--- a/test/spec/services/view.coffee
+++ b/test/spec/services/view.coffee
@@ -29,13 +29,16 @@ describe 'viewService', ->
         url: '/home/second/foo/bar/baz'
       .state 'alien',
         url: '/crazy/route'
+      .state 'up',
+        url: '/whatever'
+        data: up: 'home'
     return
 
   viewService = null
   state = null
   scope = null
 
-  home = second = third = fourth = fifth = alien = faroff = null
+  home = second = third = fourth = fifth = alien = faroff = up =null
 
 
   beforeEach inject ($rootScope, bpView, $state) ->
@@ -49,6 +52,7 @@ describe 'viewService', ->
     fifth = state.get 'fifth'
     alien = state.get 'alien'
     faroff = state.get 'faroff'
+    up = state.get 'up'
 
 
   describe 'listen', ->
@@ -113,10 +117,12 @@ describe 'viewService', ->
       expect(viewService.getDirection home, second).toBe 'normal'
       expect(viewService.getDirection second, third).toBe 'normal'
       expect(viewService.getDirection home, faroff).toBe 'normal'
+      expect(viewService.getDirection home, up).toBe 'normal'
 
     it 'should detect "reverse"', ->
       expect(viewService.getDirection second, home).toBe 'reverse'
       expect(viewService.getDirection faroff, home).toBe 'reverse'
+      expect(viewService.getDirection up, home).toBe 'reverse'
 
     it 'should detect no direction', ->
       expect(viewService.getDirection fourth, fifth).toBe null


### PR DESCRIPTION
- [x] multiline chaining calls again
- [x] remove use of `_ref`
- [x] use `i` rather than `_i` in for loops
- [x] don't use `__bind` magic
- [x] remove class magic (outer block): bpTap, bpView,
- [x] untangle ternaries
- [x] use angular helpers (`angular.isDefined() angular.isFunction`, etc.)
- [ ] more?!
