### PR TITLE
Intelligent defaults for Transition types

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -16,7 +16,6 @@
       url: '/animations',
       templateUrl: 'animations/index.html',
       data: {
-        transition: 'slide',
         up: 'app'
       }
     }).state('cover', {
@@ -31,13 +30,6 @@
       templateUrl: 'animations/transition.html',
       data: {
         transition: 'fade',
-        up: 'animations'
-      }
-    }).state('flip', {
-      url: '/animations/flip',
-      templateUrl: 'animations/transition.html',
-      data: {
-        transition: 'flip',
         up: 'animations'
       }
     }).state('scale', {
@@ -58,48 +50,42 @@
       url: '/directives',
       templateUrl: 'directives/index.html',
       data: {
-        transition: 'slide',
         up: 'app'
       }
     }).state('button', {
       url: '/directives/button',
       templateUrl: 'directives/button.html',
       data: {
-        transition: 'slide',
         up: 'directives'
       }
     }).state('cell', {
       url: '/directives/cell',
       templateUrl: 'directives/cell.html',
       data: {
-        transition: 'slide',
         up: 'directives'
       }
     }).state('detail-disclosure', {
       url: '/directives/detail-disclosure',
       templateUrl: 'directives/detail-disclosure.html',
       data: {
-        transition: 'slide',
         up: 'directives'
       }
     }).state('detail-disclosure-site', {
       url: '/directives/detail-disclosure/site',
       templateUrl: 'directives/detail-disclosure/site.html',
       data: {
-        transition: 'cover'
+        modal: true
       }
     }).state('detail-disclosure-detail', {
       url: '/directives/detail-disclosure/detail',
       templateUrl: 'directives/detail-disclosure/detail.html',
       data: {
-        transition: 'slide',
         up: 'detail-disclosure'
       }
     }).state('icon', {
       url: '/directives/icon',
       templateUrl: 'directives/icon.html',
       data: {
-        transition: 'slide',
         up: 'directives'
       }
     }).state('iscroll', {
@@ -107,7 +93,6 @@
       templateUrl: 'directives/iscroll.html',
       controller: 'DemoDataCtrl',
       data: {
-        transition: 'slide',
         up: 'directives',
         title: 'iScroll'
       }
@@ -115,7 +100,6 @@
       url: '/directives/iscroll/sticky',
       templateUrl: 'directives/iscroll/sticky.html',
       data: {
-        transition: 'slide',
         up: 'iscroll',
         title: 'iScroll-sticky'
       }
@@ -123,7 +107,6 @@
       url: '/directives/navbar',
       templateUrl: 'directives/navbar.html',
       data: {
-        transition: 'slide',
         up: 'directives'
       }
     }).state('scroll', {
@@ -131,28 +114,24 @@
       templateUrl: 'directives/scroll.html',
       controller: 'DemoDataCtrl',
       data: {
-        transition: 'slide',
         up: 'directives'
       }
     }).state('scroll-sticky', {
       url: '/directives/scroll/sticky',
       templateUrl: 'directives/scroll/sticky.html',
       data: {
-        transition: 'slide',
         up: 'scroll'
       }
     }).state('search', {
       url: '/directives/search',
       templateUrl: 'directives/search.html',
       data: {
-        transition: 'slide',
         up: 'directives'
       }
     }).state('tabbar', {
       url: '/directives/tabbar',
       templateUrl: 'directives/tabbar.html',
       data: {
-        transition: 'slide',
         up: 'directives'
       }
     }).state('first', {
@@ -199,14 +178,12 @@
       url: '/directives/table-header',
       templateUrl: 'directives/table-header.html',
       data: {
-        transition: 'slide',
         up: 'directives'
       }
     }).state('table', {
       url: '/directives/table',
       templateUrl: 'directives/table.html',
       data: {
-        transition: 'slide',
         up: 'directives'
       }
     }).state('table-grouped', {
@@ -214,7 +191,6 @@
       templateUrl: 'directives/table/grouped.html',
       controller: 'DemoDataCtrl',
       data: {
-        transition: 'slide',
         up: 'table'
       }
     }).state('table-plain', {
@@ -222,7 +198,6 @@
       templateUrl: 'directives/table/plain.html',
       controller: 'DemoDataCtrl',
       data: {
-        transition: 'slide',
         up: 'table'
       }
     }).state('table-section', {
@@ -230,21 +205,18 @@
       templateUrl: 'directives/table/section.html',
       controller: 'DemoDataCtrl',
       data: {
-        transition: 'slide',
         up: 'table'
       }
     }).state('tap', {
       url: '/directives/tap',
       templateUrl: 'directives/tap.html',
       data: {
-        transition: 'slide',
         up: 'directives'
       }
     }).state('toolbar', {
       url: '/directives/toolbar',
       templateUrl: 'directives/toolbar.html',
       data: {
-        transition: 'slide',
         up: 'directives'
       }
     });

--- a/modules/scripts/directives/navigation.js
+++ b/modules/scripts/directives/navigation.js
@@ -30,7 +30,10 @@ angular.module('bp')
         scope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState) {
           var $navbar = angular.element()
           var navbarConfig = ctrl.configs[toState.name] || {}
-          var direction = bpView.getDirection(fromState,toState)
+          var direction = bpView.getDirection(fromState, toState)
+          var isSlide = bpView.getType(fromState, toState, direction) === 'slide'
+          var isIos = bpConfig.platform === 'ios'
+
           if (!navbarConfig.noNavbar) {
             $navbar = angular.element('<bp-navbar>')
               .append(navbarConfig.$actions)
@@ -44,7 +47,7 @@ angular.module('bp')
             $compile($navbar)(scope)
           }
 
-          if (bpConfig.platform === 'ios' && angular.isElement($oldNavbar)) {
+          if (isIos && isSlide && angular.isElement($oldNavbar)) {
             var animation = 'bp-navbar-' + direction
             $animate.enter($navbar.addClass(animation),$wrapper);
             $animate.leave($oldNavbar.addClass(animation), function() {

--- a/modules/scripts/services/view.js
+++ b/modules/scripts/services/view.js
@@ -1,4 +1,4 @@
-angular.module('bp').service('bpView', function($rootScope) {
+angular.module('bp').service('bpView', function($rootScope, bpConfig) {
   function BpView() {
     this.onViewContentLoaded  = angular.bind(this, this.onViewContentLoaded)
     this.onStateChangeStart   = angular.bind(this, this.onStateChangeStart)
@@ -74,16 +74,24 @@ angular.module('bp').service('bpView', function($rootScope) {
   }
 
   BpView.prototype.getType = function(from, to, direction) {
-    if (direction === 'reverse') {
-      if (angular.isObject(from.data)) {
-        return from.data.transition || null
-      }
-    } else {
-      if (angular.isObject(to.data)) {
-        return to.data.transition || null
+    var typeFromState = function(state) {
+      var data = state.data
+      var hasData = angular.isObject(data)
+
+      if (hasData && angular.isString(data.transition)) {
+        return data.transition
+      } else if (hasData && data.modal) {
+        return 'cover'
+      } else {
+        return bpConfig.platform === 'ios' ? 'slide' : 'scale'
       }
     }
-    return null
+
+    if (direction === 'reverse') {
+      return typeFromState(from)
+    } else {
+      return typeFromState(to)
+    }
   }
 
   BpView.prototype._getURLSegments = function(state) {

--- a/modules/styles/animations/scale/module.less
+++ b/modules/styles/animations/scale/module.less
@@ -1,21 +1,25 @@
-.bp-scale (@direction: normal, @name: scale, @duration: 0.3s) {
+.bp-scale (@direction: normal, @name: scale, @duration: 0.1s) {
   @enter: ~`'@{direction}' === 'normal' ? 0 : 1`;
   @leave: ~`'@{direction}' === 'normal' ? 1 : 0`;
 
   .@{name}-@{direction}.ng-enter {
     .transition(all @duration ease-in);
-    .scale(@enter);
-    z-index: ~`'@{leave}' === '1' ? 1000 : 'inherit'`;
+    .scale(~`'@{enter}' === '1' ? 1 : 0.9`);
+    opacity: @enter;
+    z-index: ~`'@{enter}' === '1' ? 'inherit' : 1000`;
   }
   .@{name}-@{direction}.ng-enter.ng-enter-active {
     .scale(1);
+    opacity: 1;
   }
   .@{name}-@{direction}.ng-leave {
     .transition(all @duration ease-in);
     .scale(1);
-    z-index: ~`'@{enter}' === '1' ? 1000 : 'inherit'`;
+    opacity: 1;
+    z-index: ~`'@{leave}' === '1' ? 'inherit' : 1000`;
   }
   .@{name}-@{direction}.ng-leave.ng-leave-active {
-    .scale(@leave);
+    .scale(~`'@{leave}' === '1' ? 1 : 0.9`);
+    opacity: @leave;
   }
 }

--- a/test/spec/services/view.js
+++ b/test/spec/services/view.js
@@ -11,25 +11,13 @@ describe('viewService', function() {
         transition: 'fade'
       }
     }).state('second', {
-      url: '/home/second',
-      data: {
-        transition: 'slide'
-      }
+      url: '/home/second'
     }).state('third', {
-      url: '/home/second/:third',
-      data: {
-        transition: 'slide'
-      }
+      url: '/home/second/:third'
     }).state('fourth', {
-      url: '/home/foo/bar/fourth',
-      data: {
-        transition: 'slide'
-      }
+      url: '/home/foo/bar/fourth'
     }).state('fifth', {
-      url: '/home/baz/fifth',
-      data: {
-        transition: 'slide'
-      }
+      url: '/home/baz/fifth'
     }).state('faroff', {
       url: '/home/second/foo/bar/baz'
     }).state('alien', {
@@ -146,9 +134,18 @@ describe('viewService', function() {
       expect(viewService.getType(home, second, 'reverse')).toBe('fade')
     })
 
-    it('should detect no type', function() {
-      expect(viewService.getType({}, {}, 'reverse')).toBe(null)
-      expect(viewService.getType({}, {}, 'normal')).toBe(null)
+    it('should read type from different configs', function() {
+      expect(viewService.getType({}, {}, 'normal')).toBe('slide')
+      expect(viewService.getType({
+        data: {
+          transition: 'scale'
+        }
+      }, {}, 'reverse')).toBe('scale')
+      expect(viewService.getType({
+        data: {
+          modal: true
+        }
+      }, {}, 'reverse')).toBe('cover')
     })
   })
 


### PR DESCRIPTION
Change the transitions algorithm in the following way:
- [x] Slide is the default transition type for iOS (if direction detected)
- [x] Scale is the default transition type for Android (if direction detected)
- [x] scale shouldn't start from `scale(0,0)`, but `scale(0.9,0.9)` or similar
- [x] use a more semantic definition for custom transitions: e.g.: `state.data.modal = true` => transition: cover, no navbar etc.
- [x] you can still set a custom transition with `state.data.transition` following the reverse/normal convention, but you won't really need it any longer 
