### PR TITLE
Read up state from URL

### DIFF
--- a/modules/scripts/directives/navbar.js
+++ b/modules/scripts/directives/navbar.js
@@ -2,6 +2,7 @@ angular.module('bp')
   .directive('bpNavbar', function(
     bpConfig,
     bpSref,
+    bpView,
     $timeout,
     $state,
     $compile) {
@@ -52,17 +53,25 @@ angular.module('bp')
 
           var $actions = clone.filter('bp-action')
 
-          if (angular.isObject(state.data) &&
-            angular.isString(state.data.up) &&
-            !angular.isDefined(attrs.bpNavbarNoUp)) {
+          var up
 
-            var ref = bpSref.parse(state.data.up)
+          if (angular.isObject(state.data) &&
+            angular.isString(state.data.up)) {
+            up = state.data.up
+          } else if (state.url) {
+            var urlSegments = bpView._getURLSegments(state)
+            up = urlSegments[urlSegments.length - 2]
+          }
+
+          if (up && !angular.isDefined(attrs.bpNavbarNoUp)) {
+
+            var ref = bpSref.parse(up)
             var upState = $state.get(ref.state)
             var upTitle = ctrl.getTitleFromState(upState)
             $arrow = angular.element('<bp-button-up>')
             $up = $compile(angular.element('<bp-action>')
               .addClass('bp-action-up')
-              .attr('bp-sref', state.data.up)
+              .attr('bp-sref', up)
               .text(upTitle))(scope)
           }
 

--- a/test/spec/directives/navbar.js
+++ b/test/spec/directives/navbar.js
@@ -12,7 +12,7 @@ describe('navbarDirective', function() {
           up: 'second'
         }
       }).state('second', {
-        url: '/second'
+        url: '/first/second'
       }).state('third', {
         url: '/third',
         data: {
@@ -119,7 +119,7 @@ describe('navbarDirective', function() {
         expect($.contains(document, element4.next().get(0))).toBe(false)
       }))
 
-      it('should parse state params from up', inject(function($compile) {
+      it('should parse state up (w/ params)', inject(function($compile) {
         state.go('third')
         timeout.flush()
         var element5 = $compile(angular.element('<bp-navbar>'))(scope)
@@ -127,6 +127,14 @@ describe('navbarDirective', function() {
 
         expect($up.text()).toBe('First')
         expect($up.attr('bp-sref')).toBe('first({foo: 1})')
+        state.go('second')
+        timeout.flush()
+        var element6 = $compile(angular.element('<bp-navbar>'))(scope)
+        $up = element6.find('.bp-action-up')
+
+        expect($up.text()).toBe('First')
+        expect($up.attr('bp-sref')).toBe('first')
+
       }))
     })
   })


### PR DESCRIPTION
@davidpfahler What do you think about reading `state.data.up` right from the url?
When a state has more than 1 URL segment we could automatically assign length-1 as the up state (if it is a state name obv).

Example:

``` js
    $stateProvider.state('customers', {
      url: '/customers',
      templateUrl: 'customers.htmll'
    }).state('customer', {
      url: '/customers/:id',
      templateUrl: 'customer.html'
    })
```

Rather than defining `data: { up: 'customers'}` on the customer state we can just read it from the URL.

It won't be right for all occasions, but probably for a lot. The rest can be defined just like it is now.
