### PR TITLE
navbar empty when state's data object has incorrect up property

### DIFF
--- a/modules/scripts/directives/navbar.js
+++ b/modules/scripts/directives/navbar.js
@@ -65,7 +65,8 @@ angular.module('bp')
     bpView,
     $timeout,
     $state,
-    $compile) {
+    $compile,
+    $log) {
 
   return {
     restrict: 'E',
@@ -127,12 +128,16 @@ angular.module('bp')
 
             var ref = bpView.parseState(up)
             var upState = $state.get(ref.state)
-            var upTitle = ctrl.getTitleFromState(upState)
-            $arrow = angular.element('<bp-button-up>')
-            $up = $compile(angular.element('<bp-action>')
-              .addClass('bp-action-up')
-              .attr('bp-sref', up)
-              .text(upTitle))(scope)
+            if (upState) {
+              var upTitle = ctrl.getTitleFromState(upState)
+              $arrow = angular.element('<bp-button-up>')
+              $up = $compile(angular.element('<bp-action>')
+                .addClass('bp-action-up')
+                .attr('bp-sref', up)
+                .text(upTitle))(scope)
+            } else {
+              $log.error('up state detection failed. No up button compiled. Check your state configuration.')
+            }
           }
 
           if (ios) {

--- a/modules/scripts/directives/navbar.js
+++ b/modules/scripts/directives/navbar.js
@@ -124,8 +124,11 @@ angular.module('bp')
             up = urlSegments[urlSegments.length - 2]
           }
 
-          if (up && !angular.isDefined(attrs.bpNavbarNoUp)) {
+          if (up && up[0] == ':') {
+            $log.error('cannot detect up state from parameter. Please set the up property on the data object in your state configuration.')
+          }
 
+          if (up && up[0] !== ':' && !angular.isDefined(attrs.bpNavbarNoUp)) {
             var ref = bpView.parseState(up)
             var upState = $state.get(ref.state)
             if (upState) {

--- a/test/spec/directives/navbar.js
+++ b/test/spec/directives/navbar.js
@@ -18,8 +18,12 @@ describe('navbarDirective', function() {
         data: {
           up: 'first({foo: 1})'
         }
+      }).state('fourth', {
+        url: '/fourth',
+        data: {
+          up: 'doesNotExist'
+        }
       })
-
     }))
 
     beforeEach(inject(function($rootScope, $compile, $state, $timeout) {
@@ -135,6 +139,11 @@ describe('navbarDirective', function() {
         expect($up.text()).toBe('First')
         expect($up.attr('bp-sref')).toBe('first')
 
+        state.go('fourth')
+        timeout.flush()
+        expect(function() {
+          $compile(angular.element('<bp-navbar>'))(scope)
+        }).not.toThrow()
       }))
     })
   })

--- a/test/spec/services/view.js
+++ b/test/spec/services/view.js
@@ -27,6 +27,8 @@ describe('viewService', function() {
       data: {
         up: 'home'
       }
+    }).state('param', {
+      url: '/home/second/:third/fourth'
     })
   }))
 
@@ -42,6 +44,7 @@ describe('viewService', function() {
     alien = state.get('alien')
     faroff = state.get('faroff')
     up = state.get('up')
+    param = state.get('param')
   }))
 
   describe('getDirection', function() {
@@ -50,12 +53,14 @@ describe('viewService', function() {
       expect(viewService.getDirection(second, third)).toBe('normal')
       expect(viewService.getDirection(home, faroff)).toBe('normal')
       expect(viewService.getDirection(home, up)).toBe('normal')
+      expect(viewService.getDirection(third, param)).toBe('normal')
     })
 
     it('should detect "reverse"', function() {
       expect(viewService.getDirection(second, home)).toBe('reverse')
       expect(viewService.getDirection(faroff, home)).toBe('reverse')
       expect(viewService.getDirection(up, home)).toBe('reverse')
+      expect(viewService.getDirection(param, third)).toBe('reverse')
     })
 
     it('should detect no direction', function() {
@@ -68,6 +73,7 @@ describe('viewService', function() {
       expect(viewService.getDirection(alien, fifth)).toBe(null)
       expect(viewService.getDirection(third, fifth)).toBe(null)
       expect(viewService.getDirection(home, alien)).toBe(null)
+      expect(viewService.getDirection(param, alien)).toBe(null)
     })
   })
 


### PR DESCRIPTION
When a state has an `up` property defined on its `data` object and the specified state does not exist, the script breaks and hence the navbar fails to compile (and appears empty).

```
$stateProvider.state('app', {
  url: '/',
  templateUrl: 'table.html',
  data: {
    up: 'asdfgh'
  }
});
```

```
TypeError: Cannot read property 'data' of null
    at getTitleFromState (http://localhost:9000/bradypodion.js:196:37)
    at http://localhost:9000/bradypodion.js:234:34
    at publicLinkFn (http://localhost:9000/bower_components/angular/angular.js:5586:29)
    at http://localhost:9000/bradypodion.js:213:11
    at nodeLinkFn (http://localhost:9000/bower_components/angular/angular.js:6271:13)
    at compositeLinkFn (http://localhost:9000/bower_components/angular/angular.js:5678:15)
    at publicLinkFn (http://localhost:9000/bower_components/angular/angular.js:5587:30)
    at http://localhost:9000/bradypodion.js:339:32
    at Scope.$broadcast (http://localhost:9000/bower_components/angular/angular.js:12329:28)
    at $state.transition.resolved.then.$state.transition (http://localhost:9000/bower_components/angular-ui-router/release/angular-ui-router.js:1822:22) <bp-navbar class="ng-scope" role="navigation"> 
```

![screen shot 2014-03-15 at 20 57 18](https://f.cloud.github.com/assets/908242/2429349/0ec94fb6-ac7c-11e3-916f-1d21dd9ceae3.png)

Problem is that the [detected upState is not checked for existence](https://github.com/excellenteasy/bradypodion/blob/master/modules/scripts/directives/navbar.js#L129).
